### PR TITLE
Changed the checkredirect class to extend the rule table.  This is so…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Querying is as simple as sending a GET to `/checkredirect` with the path to matc
 
 ### Observability
 
-The application records metrics associated with the redirect action, accessible via the `/redirectmetrics` endpoint.
+The application records metrics associated with the redirect action.
 
 ## Getting Started
 
@@ -45,7 +45,6 @@ This assumes you have the Harper stack already [installed]([Install HarperDB | H
 | ---------------- | ----------------------------------------------------- |
 | `/redirect`      | Uploading CSV or JSON files with redriects            |
 | `/checkredirect` | Query the redirector for a redirect                   |
-| `/checkmetrics`  | Get the usages of redirects (default past 90 seconds) |
 | `/rule`          | Direct REST endpoint for the rule table               |
 | `/hosts`         | Direct REST endpoint for the rule hosts               |
 | `/version`       | Direct REST endpoint for the active version table     |
@@ -151,14 +150,6 @@ The redirector has a table for storing meta information for hosts. It currently 
 ### Versioning
 
 The redirector supports versioning of the rules. Each rule can take an integer version number with a default of `0`. The intention is to enbale cut-over and roll-back for a large number of redirects at the same time.  The `version` table (schema below) holds the active version.  Updating this table will update the version number that is added to the lookup.  This can be overridded by the `v` query parameter.
-
-### Viewing Metrics
-
-Access redirect usage metrics:
-
-```
-GET /redirectmetrics
-```
 
 ## Data Model
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redirector-template",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "resources.js",
   "scripts": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -26,9 +26,6 @@ type rule @table(database: "redirects") @export {
 
     # Advanced operations
     operations: String
-    
-    # Timestamp of when this rule was last accessed (indexed for analytics purposes)
-    lastAccessed: Date @indexed
 }
 
 type hosts @table(database: "redirects") @export {


### PR DESCRIPTION
… it can inherit the RBAC set for the table.

Removed the lastAccessed field and the patch the field on read to improve performance.

Removed the redirectmetrics class.  The operations API or prometheus exporter should be used instead.

Updated README to no longer reference redirectmetrics.